### PR TITLE
PMM-1920: Standard Metrics

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -841,25 +841,37 @@ func main() {
 		log.Fatal(srv.ListenAndServeTLS(*sslCertFile, *sslKeyFile))
 	} else {
 		// http
-		reg := prometheus.NewRegistry()
-		reg.MustRegister(NewExporter(dsn))
-		handler := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+		registryHr := prometheus.NewRegistry()
+		registryHr.MustRegister(NewExporter(dsn))
+		gatherersHr := prometheus.Gatherers{
+			prometheus.DefaultGatherer,
+			registryHr,
+		}
+		handler := promhttp.HandlerFor(gatherersHr, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}
 		http.Handle(*metricPath+"-hr", handler)
 
-		reg = prometheus.NewRegistry()
-		reg.MustRegister(NewExporterMr(dsn))
-		handler = promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+		registryMr := prometheus.NewRegistry()
+		registryMr.MustRegister(NewExporterMr(dsn))
+		gatherersMr := prometheus.Gatherers{
+			prometheus.DefaultGatherer,
+			registryMr,
+		}
+		handler = promhttp.HandlerFor(gatherersMr, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}
 		http.Handle(*metricPath+"-mr", handler)
 
-		reg = prometheus.NewRegistry()
-		reg.MustRegister(NewExporterLr(dsn))
-		handler = promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+		registryLr := prometheus.NewRegistry()
+		registryLr.MustRegister(NewExporterLr(dsn))
+		gatherersLr := prometheus.Gatherers{
+			prometheus.DefaultGatherer,
+			registryLr,
+		}
+		handler = promhttp.HandlerFor(gatherersLr, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -795,11 +795,7 @@ func main() {
 
 		registryHr := prometheus.NewRegistry()
 		registryHr.MustRegister(NewExporter(dsn))
-		gatherersHr := prometheus.Gatherers{
-			prometheus.DefaultGatherer,
-			registryHr,
-		}
-		handler := promhttp.HandlerFor(gatherersHr, promhttp.HandlerOpts{})
+		handler := promhttp.HandlerFor(prometheus.Gatherers{prometheus.DefaultGatherer, registryHr}, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}
@@ -807,11 +803,7 @@ func main() {
 
 		registryMr := prometheus.NewRegistry()
 		registryMr.MustRegister(NewExporterMr(dsn))
-		gatherersMr := prometheus.Gatherers{
-			prometheus.DefaultGatherer,
-			registryHr,
-		}
-		handler = promhttp.HandlerFor(gatherersMr, promhttp.HandlerOpts{})
+		handler = promhttp.HandlerFor(registryMr, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}
@@ -819,11 +811,7 @@ func main() {
 
 		registryLr := prometheus.NewRegistry()
 		registryLr.MustRegister(NewExporterLr(dsn))
-		gatherersLr := prometheus.Gatherers{
-			prometheus.DefaultGatherer,
-			registryLr,
-		}
-		handler = promhttp.HandlerFor(gatherersLr, promhttp.HandlerOpts{})
+		handler = promhttp.HandlerFor(registryLr, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}
@@ -855,11 +843,7 @@ func main() {
 		// http
 		registryHr := prometheus.NewRegistry()
 		registryHr.MustRegister(NewExporter(dsn))
-		gatherersHr := prometheus.Gatherers{
-			prometheus.DefaultGatherer,
-			registryHr,
-		}
-		handler := promhttp.HandlerFor(gatherersHr, promhttp.HandlerOpts{})
+		handler := promhttp.HandlerFor(prometheus.Gatherers{prometheus.DefaultGatherer, registryHr}, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}
@@ -867,11 +851,7 @@ func main() {
 
 		registryMr := prometheus.NewRegistry()
 		registryMr.MustRegister(NewExporterMr(dsn))
-		gatherersMr := prometheus.Gatherers{
-			prometheus.DefaultGatherer,
-			registryMr,
-		}
-		handler = promhttp.HandlerFor(gatherersMr, promhttp.HandlerOpts{})
+		handler = promhttp.HandlerFor(registryMr, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}
@@ -879,11 +859,7 @@ func main() {
 
 		registryLr := prometheus.NewRegistry()
 		registryLr.MustRegister(NewExporterLr(dsn))
-		gatherersLr := prometheus.Gatherers{
-			prometheus.DefaultGatherer,
-			registryLr,
-		}
-		handler = promhttp.HandlerFor(gatherersLr, promhttp.HandlerOpts{})
+		handler = promhttp.HandlerFor(registryLr, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -793,25 +793,37 @@ func main() {
 		// https
 		mux := http.NewServeMux()
 
-		reg := prometheus.NewRegistry()
-		reg.MustRegister(NewExporter(dsn))
-		handler := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+		registryHr := prometheus.NewRegistry()
+		registryHr.MustRegister(NewExporter(dsn))
+		gatherersHr := prometheus.Gatherers{
+			prometheus.DefaultGatherer,
+			registryHr,
+		}
+		handler := promhttp.HandlerFor(gatherersHr, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}
 		mux.Handle(*metricPath+"-hr", handler)
 
-		reg = prometheus.NewRegistry()
-		reg.MustRegister(NewExporterMr(dsn))
-		handler = promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+		registryMr := prometheus.NewRegistry()
+		registryMr.MustRegister(NewExporterMr(dsn))
+		gatherersMr := prometheus.Gatherers{
+			prometheus.DefaultGatherer,
+			registryHr,
+		}
+		handler = promhttp.HandlerFor(gatherersMr, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}
 		mux.Handle(*metricPath+"-mr", handler)
 
-		reg = prometheus.NewRegistry()
-		reg.MustRegister(NewExporterLr(dsn))
-		handler = promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+		registryLr := prometheus.NewRegistry()
+		registryLr.MustRegister(NewExporterLr(dsn))
+		gatherersLr := prometheus.Gatherers{
+			prometheus.DefaultGatherer,
+			registryLr,
+		}
+		handler = promhttp.HandlerFor(gatherersLr, promhttp.HandlerOpts{})
 		if cfg.User != "" && cfg.Password != "" {
 			handler = &basicAuthHandler{handler: handler.ServeHTTP, user: cfg.User, password: cfg.Password}
 		}

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -330,7 +330,7 @@ func testDefaultGatherer(t *testing.T, data binData) {
 	defer cmd.Process.Kill()
 
 	for _, resolution := range []string{"hr", "mr", "lr"} {
-		body, err := get(fmt.Sprintf("http://127.0.0.1:%d/%s-%s", data.port, metricPath, resolution))
+		body, err := get(fmt.Sprintf("http://127.0.0.1:%d%s-%s", data.port, metricPath, resolution))
 		if err != nil {
 			t.Fatalf("unable to get metrics for '%s' resolution: %s", resolution, err)
 		}

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -190,9 +190,6 @@ func TestBin(t *testing.T) {
 		t.Fatalf("Failed to build: %s", err)
 	}
 
-	data := binData{
-		bin: bin,
-	}
 	tests := []func(*testing.T, binData){
 		testLandingPage,
 		testVersion,
@@ -204,9 +201,12 @@ func TestBin(t *testing.T) {
 		for _, f := range tests {
 			f := f // capture range variable
 			fName := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+			portStart++
+			data := binData{
+				bin:  bin,
+				port: portStart,
+			}
 			t.Run(fName, func(t *testing.T) {
-				portStart++
-				data.port = portStart
 				t.Parallel()
 				f(t, data)
 			})

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -312,7 +312,7 @@ func testLandingPage(t *testing.T, data binData) {
 
 func testDefaultGatherer(t *testing.T, data binData) {
 	metricPath := "/metrics"
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(
@@ -351,7 +351,7 @@ func testDefaultGatherer(t *testing.T, data binData) {
 }
 
 func get(urlToGet string) (body []byte, err error) {
-	tries := 10
+	tries := 60
 
 	// Get data, but we need to wait a bit for http server
 	for i := 0; i <= tries; i++ {

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -329,23 +329,22 @@ func testDefaultGatherer(t *testing.T, data binData) {
 	defer cmd.Wait()
 	defer cmd.Process.Kill()
 
-	for _, resolution := range []string{"hr", "mr", "lr"} {
-		body, err := get(fmt.Sprintf("http://127.0.0.1:%d%s-%s", data.port, metricPath, resolution))
-		if err != nil {
-			t.Fatalf("unable to get metrics for '%s' resolution: %s", resolution, err)
-		}
-		got := string(body)
+	const resolution = "hr"
+	body, err := get(fmt.Sprintf("http://127.0.0.1:%d%s-%s", data.port, metricPath, resolution))
+	if err != nil {
+		t.Fatalf("unable to get metrics for '%s' resolution: %s", resolution, err)
+	}
+	got := string(body)
 
-		metricsPrefixes := []string{
-			"go_gc_duration_seconds",
-			"go_goroutines",
-			"go_memstats",
-		}
+	metricsPrefixes := []string{
+		"go_gc_duration_seconds",
+		"go_goroutines",
+		"go_memstats",
+	}
 
-		for _, prefix := range metricsPrefixes {
-			if !strings.Contains(got, prefix) {
-				t.Fatalf("no metric starting with %s in resolution %s", prefix, resolution)
-			}
+	for _, prefix := range metricsPrefixes {
+		if !strings.Contains(got, prefix) {
+			t.Fatalf("no metric starting with %s in resolution %s", prefix, resolution)
 		}
 	}
 }


### PR DESCRIPTION
This restores missing standard metrics e.g. `go_goroutines`. However I'm not sure how to deal with our 3 resolutions, should we scrape those metrics in all resolutions? Or just HR? @AlekSi ?