### PR TITLE
PMM-1934: Same table names but with different cases.

### DIFF
--- a/collector/info_schema_auto_increment.go
+++ b/collector/info_schema_auto_increment.go
@@ -9,7 +9,7 @@ import (
 )
 
 const infoSchemaAutoIncrementQuery = `
-		SELECT table_schema, table_name, column_name, auto_increment,
+		SELECT t.table_schema, t.table_name, column_name, `+"`auto_increment`"+`,
 		  pow(2, case data_type
 		    when 'tinyint'   then 7
 		    when 'smallint'  then 15
@@ -18,7 +18,8 @@ const infoSchemaAutoIncrementQuery = `
 		    when 'bigint'    then 63
 		    end+(column_type like '% unsigned'))-1 as max_int
 		  FROM information_schema.tables t
-		  JOIN information_schema.columns c USING (table_schema,table_name)
+		  JOIN information_schema.columns c
+		    ON BINARY t.table_schema = c.table_schema AND BINARY t.table_name = c.table_name
 		  WHERE c.extra = 'auto_increment' AND t.auto_increment IS NOT NULL
 		`
 


### PR DESCRIPTION
If table or database name differ only with upper case vs lower case letters,
e.g. "test" and "Test" then auto_increment collector was generating error "metric ... was collected before with the same name and label values".

This is because USING/JOIN in MySQL is case-insensitive (and prone to collation settings).
For example MySQL was matching `test` table against `test` and `Test` so resulting in 2 rows, then it was matching `Test` table against `test` and `Test` so resulting in 2 additional rows - 4 in total.
 
To force proper check we can use [`BINARY`](https://dev.mysql.com/doc/refman/5.7/en/cast-functions.html#operator_binary) operator.

A simplified example:
```
CREATE DATABASE test;
USE test;
CREATE TABLE test (id INT AUTO_INCREMENT, PRIMARY KEY(id));
CREATE TABLE Test (id INT AUTO_INCREMENT, PRIMARY KEY(id));
```

Before fix:
```
mysql> SELECT t.table_name, c.table_name FROM information_schema.tables t JOIN information_schema.columns c USING (table_schema, table_name) WHERE c.extra = 'auto_increment' AND t.auto_increment IS NOT NULL;
+------------+------------+
| table_name | table_name |
+------------+------------+
| time_zone  | time_zone  |
| Test       | Test       |
| test       | Test       |
| Test       | test       |
| test       | test       |
+------------+------------+
5 rows in set (0.08 sec)
```

After fix:
```
mysql> SELECT t.table_name, c.table_name FROM information_schema.tables t JOIN information_schema.columns c ON (BINARY t.table_schema=c.table_schema AND BINARY t.table_name=c.table_name) WHERE c.extra = 'auto_increment' AND t.auto_increment IS NOT NULL;
+------------+------------+
| table_name | table_name |
+------------+------------+
| time_zone  | time_zone  |
| Test       | Test       |
| test       | test       |
+------------+------------+
3 rows in set (0.08 sec)
```