### PR TITLE
PMM-1453: fix mapping of innodb buffer pool pages

### DIFF
--- a/collector/global_status.go
+++ b/collector/global_status.go
@@ -14,7 +14,7 @@ import (
 const (
 	// Scrape query.
 	globalStatusQuery = `SHOW GLOBAL STATUS`
-	// Subsytem.
+	// Subsystem.
 	globalStatus = "global_status"
 )
 
@@ -132,7 +132,7 @@ func (ScrapeGlobalStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error 
 				)
 			case "innodb_buffer_pool_pages":
 				switch match[2] {
-				case "data", "dirty", "free", "misc":
+				case "data", "dirty", "free", "misc", "old", "total":
 					ch <- prometheus.MustNewConstMetric(
 						globalBufferPoolPagesDesc, prometheus.GaugeValue, floatVal, match[2],
 					)

--- a/collector/global_status_test.go
+++ b/collector/global_status_test.go
@@ -24,12 +24,20 @@ func TestScrapeGlobalStatus(t *testing.T) {
 		AddRow("Connection_errors_internal", "4").
 		AddRow("Handler_commit", "5").
 		AddRow("Innodb_buffer_pool_pages_data", "6").
-		AddRow("Innodb_buffer_pool_pages_flushed", "7").
-		AddRow("Innodb_rows_read", "8").
-		AddRow("Performance_schema_users_lost", "9").
+		AddRow("Innodb_buffer_pool_pages_dirty", "7").
+		AddRow("Innodb_buffer_pool_pages_free", "8").
+		AddRow("Innodb_buffer_pool_pages_misc", "9").
+		AddRow("Innodb_buffer_pool_pages_old", "10").
+		AddRow("Innodb_buffer_pool_pages_total", "11").
+		AddRow("Innodb_buffer_pool_pages_flushed", "12").
+		AddRow("Innodb_buffer_pool_pages_lru_flushed", "13").
+		AddRow("Innodb_buffer_pool_pages_made_not_young", "14").
+		AddRow("Innodb_buffer_pool_pages_made_young", "15").
+		AddRow("Innodb_rows_read", "16").
+		AddRow("Performance_schema_users_lost", "17").
 		AddRow("Slave_running", "OFF").
 		AddRow("Ssl_version", "").
-		AddRow("Uptime", "10").
+		AddRow("Uptime", "18").
 		AddRow("wsrep_cluster_status", "Primary").
 		AddRow("wsrep_local_state_uuid", "6c06e583-686f-11e6-b9e3-8336ad58138c").
 		AddRow("wsrep_cluster_state_uuid", "6c06e583-686f-11e6-b9e3-8336ad58138c").
@@ -52,11 +60,19 @@ func TestScrapeGlobalStatus(t *testing.T) {
 		{labels: labelMap{"error": "internal"}, value: 4, metricType: dto.MetricType_COUNTER},
 		{labels: labelMap{"handler": "commit"}, value: 5, metricType: dto.MetricType_COUNTER},
 		{labels: labelMap{"state": "data"}, value: 6, metricType: dto.MetricType_GAUGE},
-		{labels: labelMap{"operation": "flushed"}, value: 7, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"operation": "read"}, value: 8, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"instrumentation": "users_lost"}, value: 9, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"state": "dirty"}, value: 7, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"state": "free"}, value: 8, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"state": "misc"}, value: 9, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"state": "old"}, value: 10, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"state": "total"}, value: 11, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"operation": "flushed"}, value: 12, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"operation": "lru_flushed"}, value: 13, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"operation": "made_not_young"}, value: 14, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"operation": "made_young"}, value: 15, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"operation": "read"}, value: 16, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"instrumentation": "users_lost"}, value: 17, metricType: dto.MetricType_COUNTER},
 		{labels: labelMap{}, value: 0, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{}, value: 10, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{}, value: 18, metricType: dto.MetricType_UNTYPED},
 		{labels: labelMap{}, value: 1, metricType: dto.MetricType_UNTYPED},
 		{labels: labelMap{"wsrep_local_state_uuid": "6c06e583-686f-11e6-b9e3-8336ad58138c", "wsrep_cluster_state_uuid": "6c06e583-686f-11e6-b9e3-8336ad58138c", "wsrep_provider_version": "3.16(r5c765eb)"}, value: 1, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"aggregator": "Minimum"}, value: 0.0471057, metricType: dto.MetricType_GAUGE},


### PR DESCRIPTION
Move the following out of mysql_global_status_buffer_pool_page_changes_total into mysql_global_status_buffer_pool_pages:

```
mysql_global_status_buffer_pool_page_changes_total{operation="old"}
mysql_global_status_buffer_pool_page_changes_total{operation="total"}
```
to:
```
mysql_global_status_buffer_pool_pages{state="old"}
mysql_global_status_buffer_pool_pages{state="total"}
```

GAUGES:
* Innodb_buffer_pool_pages_data
* Innodb_buffer_pool_pages_dirty
* Innodb_buffer_pool_pages_free
* Innodb_buffer_pool_pages_misc
* Innodb_buffer_pool_pages_old
* Innodb_buffer_pool_pages_total

Everything else for `Innodb_buffer_pool_pages` is COUNTER, so:
* Innodb_buffer_pool_pages_flushed
* Innodb_buffer_pool_pages_lru_flushed
* Innodb_buffer_pool_pages_made_not_young
* Innodb_buffer_pool_pages_made_young
