### PR TITLE
PMM-2221: No rate of scrapes for MySQL & MySQL errors.

### DIFF
--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -23,9 +23,11 @@ func TestExporter(t *testing.T) {
 	}
 	defer db.Close()
 
-	exporter := New(db, []Scraper{
-		ScrapeGlobalStatus{},
-	})
+	exporter := New(
+		db,
+		[]Scraper{ScrapeGlobalStatus{}},
+		NewStats(""),
+	)
 
 	convey.Convey("Metrics describing", t, func() {
 		ch := make(chan *prometheus.Desc)


### PR DESCRIPTION
https://github.com/prometheus/mysqld_exporter/pull/235/files#r173890280

> Previously `collector.New()` was created once - in main func. Now, with new version of mysqld_exporter, `collector.New()` is created on every scrape and so is scrapes_total and scrape_errors_total leading to constant values as every time scrapes_total is reset to 0, so we get only 1 scrape. It's not total anymore.