### PR TITLE
PMM-2726: Abort on timeout.

### DIFF
--- a/collector/binlog.go
+++ b/collector/binlog.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"strconv"
 	"strings"
@@ -56,9 +57,9 @@ func (ScrapeBinlogSize) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeBinlogSize) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeBinlogSize) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var logBin uint8
-	err := db.QueryRow(logbinQuery).Scan(&logBin)
+	err := db.QueryRowContext(ctx, logbinQuery).Scan(&logBin)
 	if err != nil {
 		return err
 	}
@@ -67,7 +68,7 @@ func (ScrapeBinlogSize) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 		return nil
 	}
 
-	masterLogRows, err := db.Query(binlogQuery)
+	masterLogRows, err := db.QueryContext(ctx, binlogQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/binlog_test.go
+++ b/collector/binlog_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,7 +28,7 @@ func TestScrapeBinlogSize(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeBinlogSize{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeBinlogSize{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/engine_innodb.go
+++ b/collector/engine_innodb.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"regexp"
 	"strconv"
@@ -37,8 +38,8 @@ func (ScrapeEngineInnodbStatus) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeEngineInnodbStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	rows, err := db.Query(engineInnodbStatusQuery)
+func (ScrapeEngineInnodbStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	rows, err := db.QueryContext(ctx, engineInnodbStatusQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/engine_innodb_test.go
+++ b/collector/engine_innodb_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -140,7 +141,7 @@ END OF INNODB MONITOR OUTPUT
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeEngineInnodbStatus{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeEngineInnodbStatus{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/engine_tokudb.go
+++ b/collector/engine_tokudb.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"strings"
 
@@ -53,8 +54,8 @@ func (ScrapeEngineTokudbStatus) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeEngineTokudbStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	tokudbRows, err := db.Query(engineTokudbStatusQuery)
+func (ScrapeEngineTokudbStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	tokudbRows, err := db.QueryContext(ctx, engineTokudbStatusQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/engine_tokudb_test.go
+++ b/collector/engine_tokudb_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,7 +45,7 @@ func TestScrapeEngineTokudbStatus(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeEngineTokudbStatus{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeEngineTokudbStatus{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -24,6 +25,7 @@ func TestExporter(t *testing.T) {
 	defer db.Close()
 
 	exporter := New(
+		context.Background(),
 		db,
 		NewMetrics(""),
 		[]Scraper{
@@ -65,19 +67,20 @@ func TestGetMySQLVersion(t *testing.T) {
 	}
 	defer db.Close()
 
+	ctx := context.Background()
 	convey.Convey("MySQL version extract", t, func() {
 		mock.ExpectQuery(versionQuery).WillReturnRows(sqlmock.NewRows([]string{""}).AddRow(""))
-		convey.So(getMySQLVersion(db), convey.ShouldEqual, 999)
+		convey.So(getMySQLVersion(ctx, db), convey.ShouldEqual, 999)
 		mock.ExpectQuery(versionQuery).WillReturnRows(sqlmock.NewRows([]string{""}).AddRow("something"))
-		convey.So(getMySQLVersion(db), convey.ShouldEqual, 999)
+		convey.So(getMySQLVersion(ctx, db), convey.ShouldEqual, 999)
 		mock.ExpectQuery(versionQuery).WillReturnRows(sqlmock.NewRows([]string{""}).AddRow("10.1.17-MariaDB"))
-		convey.So(getMySQLVersion(db), convey.ShouldEqual, 10.1)
+		convey.So(getMySQLVersion(ctx, db), convey.ShouldEqual, 10.1)
 		mock.ExpectQuery(versionQuery).WillReturnRows(sqlmock.NewRows([]string{""}).AddRow("5.7.13-6-log"))
-		convey.So(getMySQLVersion(db), convey.ShouldEqual, 5.7)
+		convey.So(getMySQLVersion(ctx, db), convey.ShouldEqual, 5.7)
 		mock.ExpectQuery(versionQuery).WillReturnRows(sqlmock.NewRows([]string{""}).AddRow("5.6.30-76.3-56-log"))
-		convey.So(getMySQLVersion(db), convey.ShouldEqual, 5.6)
+		convey.So(getMySQLVersion(ctx, db), convey.ShouldEqual, 5.6)
 		mock.ExpectQuery(versionQuery).WillReturnRows(sqlmock.NewRows([]string{""}).AddRow("5.5.51-38.1"))
-		convey.So(getMySQLVersion(db), convey.ShouldEqual, 5.5)
+		convey.So(getMySQLVersion(ctx, db), convey.ShouldEqual, 5.5)
 	})
 
 	// Ensure all SQL queries were executed

--- a/collector/global_status.go
+++ b/collector/global_status.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"regexp"
 	"strconv"
@@ -86,8 +87,8 @@ func (ScrapeGlobalStatus) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeGlobalStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	globalStatusRows, err := db.Query(globalStatusQuery)
+func (ScrapeGlobalStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	globalStatusRows, err := db.QueryContext(ctx, globalStatusQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/global_status_test.go
+++ b/collector/global_status_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -47,7 +48,7 @@ func TestScrapeGlobalStatus(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeGlobalStatus{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeGlobalStatus{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/global_variables.go
+++ b/collector/global_variables.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"regexp"
 	"strconv"
@@ -123,8 +124,8 @@ func (ScrapeGlobalVariables) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeGlobalVariables) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	globalVariablesRows, err := db.Query(globalVariablesQuery)
+func (ScrapeGlobalVariables) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	globalVariablesRows, err := db.QueryContext(ctx, globalVariablesQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/global_variables_test.go
+++ b/collector/global_variables_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,7 +38,7 @@ func TestScrapeGlobalVariables(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeGlobalVariables{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeGlobalVariables{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/heartbeat.go
+++ b/collector/heartbeat.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"fmt"
@@ -71,9 +72,9 @@ func (ScrapeHeartbeat) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeHeartbeat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeHeartbeat) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	query := fmt.Sprintf(heartbeatQuery, *collectHeartbeatDatabase, *collectHeartbeatTable)
-	heartbeatRows, err := db.Query(query)
+	heartbeatRows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return err
 	}

--- a/collector/heartbeat_test.go
+++ b/collector/heartbeat_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"flag"
 	"testing"
 
@@ -33,7 +34,7 @@ func TestScrapeHeartbeat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeHeartbeat{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeHeartbeat{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_auto_increment.go
+++ b/collector/info_schema_auto_increment.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -55,8 +56,8 @@ func (ScrapeAutoIncrementColumns) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeAutoIncrementColumns) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	autoIncrementRows, err := db.Query(infoSchemaAutoIncrementQuery)
+func (ScrapeAutoIncrementColumns) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	autoIncrementRows, err := db.QueryContext(ctx, infoSchemaAutoIncrementQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_clientstats.go
+++ b/collector/info_schema_clientstats.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -146,9 +147,9 @@ func (ScrapeClientStat) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeClientStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeClientStat) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var varName, varVal string
-	err := db.QueryRow(userstatCheckQuery).Scan(&varName, &varVal)
+	err := db.QueryRowContext(ctx, userstatCheckQuery).Scan(&varName, &varVal)
 	if err != nil {
 		log.Debugln("Detailed client stats are not available.")
 		return nil
@@ -158,7 +159,7 @@ func (ScrapeClientStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 		return nil
 	}
 
-	informationSchemaClientStatisticsRows, err := db.Query(clientStatQuery)
+	informationSchemaClientStatisticsRows, err := db.QueryContext(ctx, clientStatQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_clientstats_test.go
+++ b/collector/info_schema_clientstats_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +27,7 @@ func TestScrapeClientStat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeClientStat{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeClientStat{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_cmp.go
+++ b/collector/info_schema_innodb_cmp.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -66,8 +67,8 @@ func (ScrapeInnodbCmp) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeInnodbCmp) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	informationSchemaInnodbCmpRows, err := db.Query(innodbCmpQuery)
+func (ScrapeInnodbCmp) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	informationSchemaInnodbCmpRows, err := db.QueryContext(ctx, innodbCmpQuery)
 	if err != nil {
 		log.Debugln("INNODB_CMP stats are not available.")
 		return err

--- a/collector/info_schema_innodb_cmp_test.go
+++ b/collector/info_schema_innodb_cmp_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,7 +24,7 @@ func TestScrapeInnodbCmp(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeInnodbCmp{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeInnodbCmp{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_cmpmem.go
+++ b/collector/info_schema_innodb_cmpmem.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -63,8 +64,8 @@ func (ScrapeInnodbCmpMem) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeInnodbCmpMem) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	informationSchemaInnodbCmpMemRows, err := db.Query(innodbCmpMemQuery)
+func (ScrapeInnodbCmpMem) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	informationSchemaInnodbCmpMemRows, err := db.QueryContext(ctx, innodbCmpMemQuery)
 	if err != nil {
 		log.Debugln("INNODB_CMPMEM stats are not available.")
 		return err

--- a/collector/info_schema_innodb_cmpmem_test.go
+++ b/collector/info_schema_innodb_cmpmem_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,7 +24,7 @@ func TestScrapeInnodbCmpMem(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeInnodbCmpMem{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeInnodbCmpMem{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_metrics.go
+++ b/collector/info_schema_innodb_metrics.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"regexp"
 
@@ -67,8 +68,8 @@ func (ScrapeInnodbMetrics) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeInnodbMetrics) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	innodbMetricsRows, err := db.Query(infoSchemaInnodbMetricsQuery)
+func (ScrapeInnodbMetrics) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	innodbMetricsRows, err := db.QueryContext(ctx, infoSchemaInnodbMetricsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_innodb_metrics_test.go
+++ b/collector/info_schema_innodb_metrics_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"flag"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestScrapeInnodbMetrics(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeInnodbMetrics{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeInnodbMetrics{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_sys_tablespaces.go
+++ b/collector/info_schema_innodb_sys_tablespaces.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -57,8 +58,8 @@ func (ScrapeInfoSchemaInnodbTablespaces) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeInfoSchemaInnodbTablespaces) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	tablespacesRows, err := db.Query(innodbTablespacesQuery)
+func (ScrapeInfoSchemaInnodbTablespaces) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	tablespacesRows, err := db.QueryContext(ctx, innodbTablespacesQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_innodb_sys_tablespaces_test.go
+++ b/collector/info_schema_innodb_sys_tablespaces_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,7 +25,7 @@ func TestScrapeInfoSchemaInnodbTablespaces(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeInfoSchemaInnodbTablespaces{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeInfoSchemaInnodbTablespaces{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"fmt"
@@ -166,12 +167,12 @@ func (ScrapeProcesslist) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeProcesslist) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeProcesslist) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	processQuery := fmt.Sprintf(
 		infoSchemaProcesslistQuery,
 		*processlistMinTime,
 	)
-	processlistRows, err := db.Query(processQuery)
+	processlistRows, err := db.QueryContext(ctx, processQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_query_response_time.go
+++ b/collector/info_schema_query_response_time.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"strconv"
 	"strings"
@@ -41,8 +42,8 @@ var (
 	}
 )
 
-func processQueryResponseTimeTable(db *sql.DB, ch chan<- prometheus.Metric, query string, i int) error {
-	queryDistributionRows, err := db.Query(query)
+func processQueryResponseTimeTable(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric, query string, i int) error {
+	queryDistributionRows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return err
 	}
@@ -104,9 +105,9 @@ func (ScrapeQueryResponseTime) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeQueryResponseTime) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeQueryResponseTime) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var queryStats uint8
-	err := db.QueryRow(queryResponseCheckQuery).Scan(&queryStats)
+	err := db.QueryRowContext(ctx, queryResponseCheckQuery).Scan(&queryStats)
 	if err != nil {
 		log.Debugln("Query response time distribution is not present.")
 		return nil
@@ -117,7 +118,7 @@ func (ScrapeQueryResponseTime) Scrape(db *sql.DB, ch chan<- prometheus.Metric) e
 	}
 
 	for i, query := range queryResponseTimeQueries {
-		err := processQueryResponseTimeTable(db, ch, query, i)
+		err := processQueryResponseTimeTable(ctx, db, ch, query, i)
 		// The first query should not fail if query_response_time_stats is ON,
 		// unlike the other two when the read/write tables exist only with Percona Server 5.6/5.7.
 		if i == 0 && err != nil {

--- a/collector/info_schema_query_response_time_test.go
+++ b/collector/info_schema_query_response_time_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,7 +38,7 @@ func TestScrapeQueryResponseTime(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeQueryResponseTime{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeQueryResponseTime{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_tables.go
+++ b/collector/info_schema_tables.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"fmt"
@@ -77,10 +78,10 @@ func (ScrapeTableSchema) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeTableSchema) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeTableSchema) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var dbList []string
 	if *tableSchemaDatabases == "*" {
-		dbListRows, err := db.Query(dbListQuery)
+		dbListRows, err := db.QueryContext(ctx, dbListQuery)
 		if err != nil {
 			return err
 		}
@@ -101,7 +102,7 @@ func (ScrapeTableSchema) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	}
 
 	for _, database := range dbList {
-		tableSchemaRows, err := db.Query(fmt.Sprintf(tableSchemaQuery, database))
+		tableSchemaRows, err := db.QueryContext(ctx, fmt.Sprintf(tableSchemaQuery, database))
 		if err != nil {
 			return err
 		}

--- a/collector/info_schema_tablestats.go
+++ b/collector/info_schema_tablestats.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -56,9 +57,9 @@ func (ScrapeTableStat) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeTableStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeTableStat) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var varName, varVal string
-	err := db.QueryRow(userstatCheckQuery).Scan(&varName, &varVal)
+	err := db.QueryRowContext(ctx, userstatCheckQuery).Scan(&varName, &varVal)
 	if err != nil {
 		log.Debugln("Detailed table stats are not available.")
 		return nil
@@ -68,7 +69,7 @@ func (ScrapeTableStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 		return nil
 	}
 
-	informationSchemaTableStatisticsRows, err := db.Query(tableStatQuery)
+	informationSchemaTableStatisticsRows, err := db.QueryContext(ctx, tableStatQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_tablestats_test.go
+++ b/collector/info_schema_tablestats_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,7 +28,7 @@ func TestScrapeTableStat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeTableStat{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeTableStat{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_userstats.go
+++ b/collector/info_schema_userstats.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -142,9 +143,9 @@ func (ScrapeUserStat) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeUserStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeUserStat) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var varName, varVal string
-	err := db.QueryRow(userstatCheckQuery).Scan(&varName, &varVal)
+	err := db.QueryRowContext(ctx, userstatCheckQuery).Scan(&varName, &varVal)
 	if err != nil {
 		log.Debugln("Detailed user stats are not available.")
 		return nil
@@ -154,7 +155,7 @@ func (ScrapeUserStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 		return nil
 	}
 
-	informationSchemaUserStatisticsRows, err := db.Query(userStatQuery)
+	informationSchemaUserStatisticsRows, err := db.QueryContext(ctx, userStatQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_userstats_test.go
+++ b/collector/info_schema_userstats_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +27,7 @@ func TestScrapeUserStat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeUserStat{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeUserStat{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/perf_schema_events_statements.go
+++ b/collector/perf_schema_events_statements.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"fmt"
@@ -153,7 +154,7 @@ func (ScrapePerfEventsStatements) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapePerfEventsStatements) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapePerfEventsStatements) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	perfQuery := fmt.Sprintf(
 		perfEventsStatementsQuery,
 		*perfEventsStatementsDigestTextLimit,
@@ -161,7 +162,7 @@ func (ScrapePerfEventsStatements) Scrape(db *sql.DB, ch chan<- prometheus.Metric
 		*perfEventsStatementsLimit,
 	)
 	// Timers here are returned in picoseconds.
-	perfSchemaEventsStatementsRows, err := db.Query(perfQuery)
+	perfSchemaEventsStatementsRows, err := db.QueryContext(ctx, perfQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_events_waits.go
+++ b/collector/perf_schema_events_waits.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,9 +47,9 @@ func (ScrapePerfEventsWaits) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapePerfEventsWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapePerfEventsWaits) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	// Timers here are returned in picoseconds.
-	perfSchemaEventsWaitsRows, err := db.Query(perfEventsWaitsQuery)
+	perfSchemaEventsWaitsRows, err := db.QueryContext(ctx, perfEventsWaitsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_file_events.go
+++ b/collector/perf_schema_file_events.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -55,9 +56,9 @@ func (ScrapePerfFileEvents) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapePerfFileEvents) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapePerfFileEvents) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	// Timers here are returned in picoseconds.
-	perfSchemaFileEventsRows, err := db.Query(perfFileEventsQuery)
+	perfSchemaFileEventsRows, err := db.QueryContext(ctx, perfFileEventsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_file_instances.go
+++ b/collector/perf_schema_file_instances.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"strings"
@@ -62,9 +63,9 @@ func (ScrapePerfFileInstances) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapePerfFileInstances) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapePerfFileInstances) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	// Timers here are returned in picoseconds.
-	perfSchemaFileInstancesRows, err := db.Query(perfFileInstancesQuery, *performanceSchemaFileInstancesFilter)
+	perfSchemaFileInstancesRows, err := db.QueryContext(ctx, perfFileInstancesQuery, *performanceSchemaFileInstancesFilter)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_file_instances_test.go
+++ b/collector/perf_schema_file_instances_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"testing"
@@ -33,7 +34,7 @@ func TestScrapePerfFileInstances(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfFileInstances{}).Scrape(db, ch); err != nil {
+		if err = (ScrapePerfFileInstances{}).Scrape(context.Background(), db, ch); err != nil {
 			panic(fmt.Sprintf("error calling function on test: %s", err))
 		}
 		close(ch)

--- a/collector/perf_schema_index_io_waits.go
+++ b/collector/perf_schema_index_io_waits.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -49,8 +50,8 @@ func (ScrapePerfIndexIOWaits) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapePerfIndexIOWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	perfSchemaIndexWaitsRows, err := db.Query(perfIndexIOWaitsQuery)
+func (ScrapePerfIndexIOWaits) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	perfSchemaIndexWaitsRows, err := db.QueryContext(ctx, perfIndexIOWaitsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_index_io_waits_test.go
+++ b/collector/perf_schema_index_io_waits_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,7 +26,7 @@ func TestScrapePerfIndexIOWaits(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfIndexIOWaits{}).Scrape(db, ch); err != nil {
+		if err = (ScrapePerfIndexIOWaits{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/perf_schema_table_io_waits.go
+++ b/collector/perf_schema_table_io_waits.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,8 +51,8 @@ func (ScrapePerfTableIOWaits) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapePerfTableIOWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	perfSchemaTableWaitsRows, err := db.Query(perfTableIOWaitsQuery)
+func (ScrapePerfTableIOWaits) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	perfSchemaTableWaitsRows, err := db.QueryContext(ctx, perfTableIOWaitsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_table_lock_waits.go
+++ b/collector/perf_schema_table_lock_waits.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -79,8 +80,8 @@ func (ScrapePerfTableLockWaits) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapePerfTableLockWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	perfSchemaTableLockWaitsRows, err := db.Query(perfTableLockWaitsQuery)
+func (ScrapePerfTableLockWaits) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	perfSchemaTableLockWaitsRows, err := db.QueryContext(ctx, perfTableLockWaitsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/scraper.go
+++ b/collector/scraper.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -8,7 +9,7 @@ import (
 )
 
 type Scraper interface {
-	Scrape(db *sql.DB, ch chan<- prometheus.Metric) error
+	Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error
 	Name() string
 	Help() string
 	Version() float64

--- a/collector/slave_status.go
+++ b/collector/slave_status.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -54,18 +55,18 @@ func (ScrapeSlaveStatus) Version() float64 {
 }
 
 // Scrape collects data.
-func (ScrapeSlaveStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeSlaveStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var (
 		slaveStatusRows *sql.Rows
 		err             error
 	)
 	// Try the both syntax for MySQL/Percona and MariaDB
 	for _, query := range slaveStatusQueries {
-		slaveStatusRows, err = db.Query(query)
+		slaveStatusRows, err = db.QueryContext(ctx, query)
 		if err != nil { // MySQL/Percona
 			// Leverage lock-free SHOW SLAVE STATUS by guessing the right suffix
 			for _, suffix := range slaveStatusQuerySuffixes {
-				slaveStatusRows, err = db.Query(fmt.Sprint(query, suffix))
+				slaveStatusRows, err = db.QueryContext(ctx, fmt.Sprint(query, suffix))
 				if err == nil {
 					break
 				}

--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,7 +24,7 @@ func TestScrapeSlaveStatus(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeSlaveStatus{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeSlaveStatus{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -46,7 +46,7 @@ var (
 		"Path under which to expose metrics.",
 	)
 	timeoutOffset = flag.Float64(
-		"timeout-offset", 0.5,
+		"timeout-offset", 0.25,
 		"Offset to subtract from timeout in seconds.",
 	)
 	configMycnf = flag.String(

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -45,6 +45,10 @@ var (
 		"web.telemetry-path", "/metrics",
 		"Path under which to expose metrics.",
 	)
+	scrapeTimeoutPercent = flag.Float64(
+		"web.scrape-timeout-percent", 0.8,
+		"Stop collecting data after reaching scrape-timeout-percent of scrape timeout provided by X-Prometheus-Scrape-Timeout-Seconds header.",
+	)
 	configMycnf = flag.String(
 		"config.my-cnf", path.Join(os.Getenv("HOME"), ".my.cnf"),
 		"Path to .my.cnf file to read MySQL credentials from.",
@@ -220,6 +224,7 @@ func newHandler(cfg *webAuth, db *sql.DB, metrics collector.Metrics, scrapers []
 			if err != nil {
 				log.Errorf("Failed to parse timeout from Prometheus header: %s", err)
 			} else {
+				timeoutSeconds = timeoutSeconds * *scrapeTimeoutPercent
 				var cancel context.CancelFunc
 				// Create new timeout context with request context as parent.
 				ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds*float64(time.Second)))


### PR DESCRIPTION
# Abort data collection: 
* when connection gets closed
* on prometheus scrape timeout `X-Prometheus-Scrape-Timeout-Seconds`
  * give exporter time to finish and send data with `--timeout-offset`. Default `0.5` second.

Tested manually. Returns metrics even if scraping was canceled. Example errors:
```console
ERRO[0014] Error scraping for collect.global_status: context deadline exceeded  source="exporter.go:104"
ERRO[0014] Error scraping for collect.info_schema.innodb_metrics: context deadline exceeded  source="exporter.go:104"
```

Based on https://github.com/prometheus/blackbox_exporter/blob/master/main.go#L74-L83

Upstream PR: https://github.com/prometheus/mysqld_exporter/pull/323