### PR TITLE
return 429 Too Many Requests instead of stacking up requests

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -216,7 +216,16 @@ func init() {
 }
 
 func newHandler(cfg *webAuth, db *sql.DB, metrics collector.Metrics, scrapers []collector.Scraper, defaultGatherer bool) http.HandlerFunc {
+	processing := false
 	return func(w http.ResponseWriter, r *http.Request) {
+		if processing {
+			log.Info("Received metrics request while previous still in progress: returning 429 Too Many Requests")
+			http.Error(w, "429 Too Many Requests", http.StatusTooManyRequests)
+			return
+		}
+		processing = true
+		defer func() { processing = false }()
+
 		filteredScrapers := scrapers
 		params := r.URL.Query()["collect[]"]
 		// Use request context for cancellation when connection gets closed.


### PR DESCRIPTION
Addressing https://jira.percona.com/browse/PMM-4557

We've been running this in production without issue.

Note that the `processing` flag in the closure is separate for the three levels of precision (high-, medium-, and low-resolution). This means that you can run 1 of each of those, but no more. I think this is just what we want.