### PR TITLE
PMM-5783 Fix scraping status

### DIFF
--- a/collector/info_schema_query_response_time_test.go
+++ b/collector/info_schema_query_response_time_test.go
@@ -17,6 +17,7 @@ func TestScrapeQueryResponseTime(t *testing.T) {
 	}
 	defer db.Close()
 
+	mock.ExpectQuery(sanitizeQuery(checkQueryResponseTimePlugins)).WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(1))
 	mock.ExpectQuery(queryResponseCheckQuery).WillReturnRows(sqlmock.NewRows([]string{""}).AddRow(1))
 
 	rows := sqlmock.NewRows([]string{"TIME", "COUNT", "TOTAL"}).
@@ -74,6 +75,6 @@ func TestScrapeQueryResponseTime(t *testing.T) {
 
 	// Ensure all SQL queries were executed
 	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expections: %s", err)
+		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 }

--- a/collector/slave_status.go
+++ b/collector/slave_status.go
@@ -5,19 +5,17 @@ package collector
 import (
 	"context"
 	"database/sql"
-	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 const (
 	// Subsystem.
 	slaveStatus = "slave_status"
 )
-
-var slaveStatusQueries = [2]string{"SHOW ALL SLAVES STATUS", "SHOW SLAVE STATUS"}
-var slaveStatusQuerySuffixes = [3]string{" NONBLOCKING", " NOLOCK", ""}
 
 func columnIndex(slaveCols []string, colName string) int {
 	for idx := range slaveCols {
@@ -54,30 +52,59 @@ func (ScrapeSlaveStatus) Version() float64 {
 	return 5.1
 }
 
+// chooseQuery chooses a query to get slave status by database's distro and version.
+func chooseQuery(ctx context.Context, db *sql.DB) (string, error) {
+	var (
+		version        string
+		versionComment string
+	)
+
+	if err := db.QueryRowContext(ctx, "SELECT @@version, @@version_comment").Scan(&version, &versionComment); err != nil {
+		return "", err
+	}
+	log.Infof("database version %s, distro %s", version, versionComment)
+
+	query := "SHOW SLAVE STATUS"
+	switch {
+	case strings.Contains(strings.ToLower(versionComment), "maria") && !regexp.MustCompile(`^5\.[1-5]`).MatchString(version):
+		query = "SHOW ALL SLAVES STATUS"
+	case strings.Contains(strings.ToLower(versionComment), "percona") && (regexp.MustCompile(`^5\.6\.1[1-9]`).MatchString(version) || regexp.MustCompile(`^5\.5`).MatchString(version)):
+		// https://www.percona.com/doc/percona-server/5.6/reliability/show_slave_status_nolock.html
+		// > 5.6.11-60.3: Feature ported from Percona Server for MySQL 5.5.
+		query = "SHOW SLAVE STATUS NOLOCK" // Percona Server v >= 5.6.11
+	case strings.Contains(strings.ToLower(versionComment), "percona") && regexp.MustCompile(`^5\.6\.[2-9][0-9]`).MatchString(version):
+		// https://www.percona.com/doc/percona-server/5.6/reliability/show_slave_status_nolock.html
+		// > 5.6.20-68.0: Percona Server for MySQL implemented the NONBLOCKING syntax from MySQL 5.7 and deprecated the NOLOCK syntax.
+		// > 5.6.27-76.0: SHOW SLAVE STATUS NOLOCK syntax in 5.6 has been undeprecated. Both SHOW SLAVE STATUS NOLOCK and SHOW SLAVE STATUS NONBLOCKING are now supported.
+		query = "SHOW SLAVE STATUS NONBLOCKING"
+	}
+	return query, nil
+}
+
 // Scrape collects data.
 func (ScrapeSlaveStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var (
 		slaveStatusRows *sql.Rows
 		err             error
 	)
-	// Try the both syntax for MySQL/Percona and MariaDB
-	for _, query := range slaveStatusQueries {
-		slaveStatusRows, err = db.QueryContext(ctx, query)
-		if err != nil { // MySQL/Percona
-			// Leverage lock-free SHOW SLAVE STATUS by guessing the right suffix
-			for _, suffix := range slaveStatusQuerySuffixes {
-				slaveStatusRows, err = db.QueryContext(ctx, fmt.Sprint(query, suffix))
-				if err == nil {
-					break
-				}
-			}
-		} else { // MariaDB
-			break
-		}
-	}
+
+	query, err := chooseQuery(ctx, db)
 	if err != nil {
 		return err
 	}
+
+	if slaveStatusRows, err = db.QueryContext(ctx, query); err != nil {
+		log.Errorf("cannot scrape status with a chosen query %q: %v", query, err)
+		// fallback to the common query.
+		query = "SHOW SLAVE STATUS"
+		if slaveStatusRows, err = db.QueryContext(ctx, query); err != nil {
+			log.Errorf("cannot scrape status by the common query: %v", err)
+			return err
+		}
+	}
+
+	log.Infof("Successfully scraped status with query: %s", query)
+
 	defer slaveStatusRows.Close()
 
 	slaveCols, err := slaveStatusRows.Columns()

--- a/collector/slave_status.go
+++ b/collector/slave_status.go
@@ -54,9 +54,9 @@ func (ScrapeSlaveStatus) Version() float64 {
 
 var (
 	maria55              = regexp.MustCompile(`^5\.[1-5]`)         // support only SHOW SLAVE STATUS
-	perconaNolock55      = regexp.MustCompile(`^5\.5`)             // suport SHOW SLAVE STATUS NOLOCK
-	perconaNolock56      = regexp.MustCompile(`^5\.6\.1[1-9]`)     // suport SHOW SLAVE STATUS NOLOCK
-	perconaNonblocking56 = regexp.MustCompile(`^5\.6\.[2-9][0-9]`) // suport SHOW SLAVE STATUS NONBLOCKING
+	perconaNolock55      = regexp.MustCompile(`^5\.5`)             // support SHOW SLAVE STATUS NOLOCK
+	perconaNolock56      = regexp.MustCompile(`^5\.6\.1[1-9]`)     // support SHOW SLAVE STATUS NOLOCK
+	perconaNonblocking56 = regexp.MustCompile(`^5\.6\.[2-9][0-9]`) // support SHOW SLAVE STATUS NONBLOCKING
 )
 
 // chooseQuery chooses a query to get slave status by database's distro and version.

--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -133,9 +133,9 @@ func TestScrapeSlaveStatusVersions(t *testing.T) {
 		defer db.Close()
 
 		versionColumns := []string{"@@version", "@@version_comment"}
-		vesionRows := sqlmock.NewRows(versionColumns).
+		versionRows := sqlmock.NewRows(versionColumns).
 			AddRow(qt.version...)
-		mock.ExpectQuery(sanitizeQuery("SELECT @@version, @@version_comment")).WillReturnRows(vesionRows)
+		mock.ExpectQuery(sanitizeQuery("SELECT @@version, @@version_comment")).WillReturnRows(versionRows)
 
 		columns := []string{"Master_Host", "Read_Master_Log_Pos", "Slave_IO_Running", "Slave_SQL_Running", "Seconds_Behind_Master"}
 		rows := sqlmock.NewRows(columns).

--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -19,9 +19,9 @@ func TestScrapeSlaveStatus(t *testing.T) {
 	defer db.Close()
 
 	versionColumns := []string{"@@version", "@@version_comment"}
-	vesionRows := sqlmock.NewRows(versionColumns).
+	versionRows := sqlmock.NewRows(versionColumns).
 		AddRow("8.0.21", "MySQL Community Server - GPL")
-	mock.ExpectQuery(sanitizeQuery("SELECT @@version, @@version_comment")).WillReturnRows(vesionRows)
+	mock.ExpectQuery(sanitizeQuery("SELECT @@version, @@version_comment")).WillReturnRows(versionRows)
 
 	columns := []string{"Master_Host", "Read_Master_Log_Pos", "Slave_IO_Running", "Slave_SQL_Running", "Seconds_Behind_Master"}
 	rows := sqlmock.NewRows(columns).

--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -51,7 +51,7 @@ func TestScrapeSlaveStatus(t *testing.T) {
 
 	// Ensure all SQL queries were executed
 	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expections: %s", err)
+		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 }
 
@@ -162,7 +162,7 @@ func TestScrapeSlaveStatusVersions(t *testing.T) {
 
 		// Ensure all SQL queries were executed
 		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Errorf("there were unfulfilled expections: %s", err)
+			t.Errorf("there were unfulfilled expectations: %s", err)
 		}
 	}
 }

--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"database/sql/driver"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,6 +17,11 @@ func TestScrapeSlaveStatus(t *testing.T) {
 		t.Fatalf("error opening a stub database connection: %s", err)
 	}
 	defer db.Close()
+
+	versionColumns := []string{"@@version", "@@version_comment"}
+	vesionRows := sqlmock.NewRows(versionColumns).
+		AddRow("8.0.21", "MySQL Community Server - GPL")
+	mock.ExpectQuery(sanitizeQuery("SELECT @@version, @@version_comment")).WillReturnRows(vesionRows)
 
 	columns := []string{"Master_Host", "Read_Master_Log_Pos", "Slave_IO_Running", "Slave_SQL_Running", "Seconds_Behind_Master"}
 	rows := sqlmock.NewRows(columns).
@@ -46,5 +52,117 @@ func TestScrapeSlaveStatus(t *testing.T) {
 	// Ensure all SQL queries were executed
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expections: %s", err)
+	}
+}
+
+func TestScrapeSlaveStatusVersions(t *testing.T) {
+
+	queryTable := []struct {
+		version []driver.Value
+		query   string
+	}{
+		// MariaDB
+		{
+			version: []driver.Value{"10.5.4-MariaDB-1:10.5.4+maria~focal", "mariadb.org binary distribution"},
+			query:   "SHOW ALL SLAVES STATUS",
+		},
+		{
+			version: []driver.Value{"10.4.13-MariaDB-1:10.4.13+maria~focal", "mariadb.org binary distribution"},
+			query:   "SHOW ALL SLAVES STATUS",
+		},
+		{
+			version: []driver.Value{"10.3.23-MariaDB-1:10.3.23+maria~focal", "mariadb.org binary distribution"},
+			query:   "SHOW ALL SLAVES STATUS",
+		},
+		{
+			version: []driver.Value{"10.2.32-MariaDB-1:10.2.32+maria~bionic", "mariadb.org binary distribution"},
+			query:   "SHOW ALL SLAVES STATUS",
+		},
+		{
+			version: []driver.Value{"10.1.45-MariaDB-1~bionic", "mariadb.org binary distribution"},
+			query:   "SHOW ALL SLAVES STATUS",
+		},
+		{
+			version: []driver.Value{"5.5.64-MariaDB-1~trusty", "mariadb.org binary distribution"},
+			query:   "SHOW SLAVE STATUS",
+		},
+
+		// MySQL
+		{
+			version: []driver.Value{"8.0.21", "MySQL Community Server - GPL"},
+			query:   "SHOW SLAVE STATUS",
+		},
+		{
+			version: []driver.Value{"5.7.31", "MySQL Community Server (GPL)"},
+			query:   "SHOW SLAVE STATUS",
+		},
+		{
+			version: []driver.Value{"5.6.49", "MySQL Community Server (GPL)"},
+			query:   "SHOW SLAVE STATUS",
+		},
+		{
+			version: []driver.Value{"5.5.62", "MySQL Community Server (GPL)"},
+			query:   "SHOW SLAVE STATUS",
+		},
+
+		// Percona Server
+		{
+			version: []driver.Value{"8.0.19-10", "Percona Server (GPL), Release 10, Revision f446c04"},
+			query:   "SHOW SLAVE STATUS",
+		},
+		{
+			version: []driver.Value{"5.7.30-33", "Percona Server (GPL), Release 33, Revision 6517692"},
+			query:   "SHOW SLAVE STATUS",
+		},
+		{
+			version: []driver.Value{"5.6.48-88.0", "Percona Server (GPL), Release 88.0, Revision 66735bc"},
+			query:   "SHOW SLAVE STATUS NONBLOCKING",
+		},
+		{
+			version: []driver.Value{"5.5.61-38.13", "Percona Server (GPL), Release 38.13, Revision 812705b"},
+			query:   "SHOW SLAVE STATUS NOLOCK",
+		},
+	}
+
+	for _, qt := range queryTable {
+
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("error opening a stub database connection: %s", err)
+		}
+		defer db.Close()
+
+		versionColumns := []string{"@@version", "@@version_comment"}
+		vesionRows := sqlmock.NewRows(versionColumns).
+			AddRow(qt.version...)
+		mock.ExpectQuery(sanitizeQuery("SELECT @@version, @@version_comment")).WillReturnRows(vesionRows)
+
+		columns := []string{"Master_Host", "Read_Master_Log_Pos", "Slave_IO_Running", "Slave_SQL_Running", "Seconds_Behind_Master"}
+		rows := sqlmock.NewRows(columns).
+			AddRow("127.0.0.1", "1", "Connecting", "Yes", "2")
+		mock.ExpectQuery(sanitizeQuery(qt.query)).WillReturnRows(rows)
+
+		ch := make(chan prometheus.Metric)
+		go func() {
+			if err = (ScrapeSlaveStatus{}).Scrape(context.Background(), db, ch); err != nil {
+				t.Errorf("error calling function on test: %s", err)
+			}
+			close(ch)
+		}()
+
+		counterExpected := []MetricResult{
+			{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
+		}
+		convey.Convey("Metrics comparison", t, func() {
+			for _, expect := range counterExpected {
+				got := readMetric(<-ch)
+				convey.So(got, convey.ShouldResemble, expect)
+			}
+		})
+
+		// Ensure all SQL queries were executed
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("there were unfulfilled expections: %s", err)
+		}
 	}
 }


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-5783

https://github.com/Percona-Lab/pmm-submodules/pull/971

**logs:**
```
INFO[2020-07-21T12:27:26.646+00:00] time="2020-07-21T12:27:26Z" level=info msg="database version 10.1.45-MariaDB-1~bionic, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/d6242fea-606c-42b2-9d1f-b98b8e88ef2b component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:26.647+00:00] time="2020-07-21T12:27:26Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/d6242fea-606c-42b2-9d1f-b98b8e88ef2b component=agent-process
 type=mysqld_exporter
INFO[2020-07-21T12:27:26.973+00:00] time="2020-07-21T12:27:26Z" level=info msg="database version 5.5.64-MariaDB-1~trusty, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/9b05467b-2b27-4951-9fdf-9590646e2070 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:26.974+00:00] time="2020-07-21T12:27:26Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/9b05467b-2b27-4951-9fdf-9590646e2070 component=agent-process type
=mysqld_exporter
INFO[2020-07-21T12:27:27.378+00:00] time="2020-07-21T12:27:27Z" level=error msg="Error scraping for collect.info_schema.innodb_metrics: Error 1054: Unknown column 'status' in 'where clause'" source="exporter.go:116"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:27:29.536+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/171a4b8f-1d4a-4d2d-b6a5-287eab87a485 component=agent-builtin type=qan_mysql
_perfschema_agent
INFO[2020-07-21T12:27:31.230+00:00] time="2020-07-21T12:27:31Z" level=info msg="database version 10.2.32-MariaDB-1:10.2.32+maria~bionic, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/8d8f5753-d3a4-4dae-bc85-e6685f061114 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:31.232+00:00] time="2020-07-21T12:27:31Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/8d8f5753-d3a4-4dae-bc85-e6685f061114 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:32.377+00:00] time="2020-07-21T12:27:32Z" level=error msg="Error scraping for collect.info_schema.innodb_metrics: Error 1054: Unknown column 'status' in 'where clause'" source="exporter.go:116"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:32.707+00:00] time="2020-07-21T12:27:32Z" level=info msg="database version 10.3.23-MariaDB-1:10.3.23+maria~focal, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/68e9e507-289b-4728-b977-c9834a88a5b2 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:32.708+00:00] time="2020-07-21T12:27:32Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/68e9e507-289b-4728-b977-c9834a88a5b2 component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:27:34.538+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/171a4b8f-1d4a-4d2d-b6a5-287eab87a485 component=agent-builtin type=qan_mysql
_perfschema_agent
INFO[2020-07-21T12:27:35.068+00:00] time="2020-07-21T12:27:35Z" level=info msg="database version 10.4.13-MariaDB-1:10.4.13+maria~focal, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/b8b3b002-87c1-4e9e-ab26-b3b0d7ef5030 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:35.069+00:00] time="2020-07-21T12:27:35Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/b8b3b002-87c1-4e9e-ab26-b3b0d7ef5030 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:35.086+00:00] time="2020-07-21T12:27:35Z" level=info msg="database version 10.5.4-MariaDB-1:10.5.4+maria~focal, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:35.087+00:00] time="2020-07-21T12:27:35Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:36.607+00:00] time="2020-07-21T12:27:36Z" level=info msg="database version 10.1.45-MariaDB-1~bionic, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/d6242fea-606c-42b2-9d1f-b98b8e88ef2b component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:36.608+00:00] time="2020-07-21T12:27:36Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/d6242fea-606c-42b2-9d1f-b98b8e88ef2b component=agent-process
 type=mysqld_exporter
INFO[2020-07-21T12:27:36.934+00:00] time="2020-07-21T12:27:36Z" level=info msg="database version 5.5.64-MariaDB-1~trusty, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/9b05467b-2b27-4951-9fdf-9590646e2070 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:36.935+00:00] time="2020-07-21T12:27:36Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/9b05467b-2b27-4951-9fdf-9590646e2070 component=agent-process type
=mysqld_exporter
INFO[2020-07-21T12:27:37.343+00:00] time="2020-07-21T12:27:37Z" level=error msg="Error scraping for collect.info_schema.innodb_metrics: Error 1054: Unknown column 'status' in 'where clause'" source="exporter.go:116"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:27:39.502+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/171a4b8f-1d4a-4d2d-b6a5-287eab87a485 component=agent-builtin type=qan_mysql
_perfschema_agent
INFO[2020-07-21T12:27:41.196+00:00] time="2020-07-21T12:27:41Z" level=info msg="database version 10.2.32-MariaDB-1:10.2.32+maria~bionic, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/8d8f5753-d3a4-4dae-bc85-e6685f061114 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:41.198+00:00] time="2020-07-21T12:27:41Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/8d8f5753-d3a4-4dae-bc85-e6685f061114 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:42.115+00:00] time="2020-07-21T12:27:42Z" level=error msg="Error scraping for collect.info_schema.innodb_tablespaces: Error 1054: Unknown column 'SPACE_TYPE' in 'field list'" source="exporter.go:116"  agentID=/agent_id/d6242fea-606c-42b2-9d1f-b98b8e88ef2b component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:42.117+00:00] time="2020-07-21T12:27:42Z" level=error msg="Error scraping for collect.engine_tokudb_status: Error 1286: Unknown storage engine 'TOKUDB'" source="exporter.go:116"  agentID=/agent_id/d6242fea-606c-42b2-9d1f-b98b8e88ef2b component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:42.118+00:00] time="2020-07-21T12:27:42Z" level=error msg="Error scraping for collect.heartbeat: Error 1146: Table 'heartbeat.heartbeat' doesn't exist" source="exporter.go:116"  agentID=/agent_id/d6242fea-606c-42b2-9d1f-b98b8e88ef
2b component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:42.343+00:00] time="2020-07-21T12:27:42Z" level=error msg="Error scraping for collect.info_schema.innodb_metrics: Error 1054: Unknown column 'status' in 'where clause'" source="exporter.go:116"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:42.667+00:00] time="2020-07-21T12:27:42Z" level=info msg="database version 10.3.23-MariaDB-1:10.3.23+maria~focal, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/68e9e507-289b-4728-b977-c9834a88a5b2 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:42.669+00:00] time="2020-07-21T12:27:42Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/68e9e507-289b-4728-b977-c9834a88a5b2 component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:27:44.503+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/171a4b8f-1d4a-4d2d-b6a5-287eab87a485 component=agent-builtin type=qan_mysql
_perfschema_agent
INFO[2020-07-21T12:27:45.069+00:00] time="2020-07-21T12:27:45Z" level=info msg="database version 10.4.13-MariaDB-1:10.4.13+maria~focal, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/b8b3b002-87c1-4e9e-ab26-b3b0d7ef5030 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:45.070+00:00] time="2020-07-21T12:27:45Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/b8b3b002-87c1-4e9e-ab26-b3b0d7ef5030 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:45.087+00:00] time="2020-07-21T12:27:45Z" level=info msg="database version 10.5.4-MariaDB-1:10.5.4+maria~focal, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:45.087+00:00] time="2020-07-21T12:27:45Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:46.605+00:00] time="2020-07-21T12:27:46Z" level=info msg="database version 10.1.45-MariaDB-1~bionic, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/d6242fea-606c-42b2-9d1f-b98b8e88ef2b component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:46.606+00:00] time="2020-07-21T12:27:46Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/d6242fea-606c-42b2-9d1f-b98b8e88ef2b component=agent-process
 type=mysqld_exporter
INFO[2020-07-21T12:27:46.822+00:00] time="2020-07-21T12:27:46Z" level=error msg="Error scraping for collect.engine_tokudb_status: Error 1286: Unknown storage engine 'TOKUDB'" source="exporter.go:116"  agentID=/agent_id/8d8f5753-d3a4-4dae-bc85-e6685f061114 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:46.826+00:00] time="2020-07-21T12:27:46Z" level=error msg="Error scraping for collect.heartbeat: Error 1146: Table 'heartbeat.heartbeat' doesn't exist" source="exporter.go:116"  agentID=/agent_id/8d8f5753-d3a4-4dae-bc85-e6685f061114 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:46.934+00:00] time="2020-07-21T12:27:46Z" level=info msg="database version 5.5.64-MariaDB-1~trusty, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/9b05467b-2b27-4951-9fdf-9590646e2070 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:46.934+00:00] time="2020-07-21T12:27:46Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/9b05467b-2b27-4951-9fdf-9590646e2070 component=agent-process type
=mysqld_exporter
INFO[2020-07-21T12:27:47.344+00:00] time="2020-07-21T12:27:47Z" level=error msg="Error scraping for collect.info_schema.innodb_metrics: Error 1054: Unknown column 'status' in 'where clause'" source="exporter.go:116"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:27:49.503+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/171a4b8f-1d4a-4d2d-b6a5-287eab87a485 component=agent-builtin type=qan_mysql
_perfschema_agent
INFO[2020-07-21T12:27:51.194+00:00] time="2020-07-21T12:27:51Z" level=info msg="database version 10.2.32-MariaDB-1:10.2.32+maria~bionic, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/8d8f5753-d3a4-4dae-bc85-e6685f061114 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:51.196+00:00] time="2020-07-21T12:27:51Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/8d8f5753-d3a4-4dae-bc85-e6685f061114 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:52.344+00:00] time="2020-07-21T12:27:52Z" level=error msg="Error scraping for collect.info_schema.innodb_metrics: Error 1054: Unknown column 'status' in 'where clause'" source="exporter.go:116"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:52.416+00:00] time="2020-07-21T12:27:52Z" level=error msg="Error scraping for collect.engine_tokudb_status: Error 1286: Unknown storage engine 'TOKUDB'" source="exporter.go:116"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:52.418+00:00] time="2020-07-21T12:27:52Z" level=error msg="Error scraping for collect.heartbeat: Error 1146: Table 'heartbeat.heartbeat' doesn't exist" source="exporter.go:116"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:52.418+00:00] time="2020-07-21T12:27:52Z" level=error msg="Error scraping for collect.info_schema.innodb_tablespaces: Error 1054: Unknown column 'FILE_FORMAT' in 'field list'" source="exporter.go:116"  agentID=/agent_id/b22e710b-810e-427b-a8c3-ae81f0be81ea component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:52.670+00:00] time="2020-07-21T12:27:52Z" level=info msg="database version 10.3.23-MariaDB-1:10.3.23+maria~focal, distro mariadb.org binary distribution" source="slave_status.go:65"  agentID=/agent_id/68e9e507-289b-4728-b977-c9834a88a5b2 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:27:52.671+00:00] time="2020-07-21T12:27:52Z" level=info msg="Successfully scraped status with query: SHOW ALL SLAVES STATUS" source="slave_status.go:106"  agentID=/agent_id/68e9e507-289b-4728-b977-c9834a88a5b2 component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:27:54.501+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/171a4b8f-1d4a-4d2d-b6a5-287eab87a485 component=agent-builtin type=qan_mysql
_peINFO[2020-07-21T12:54:44.133+00:00] time="2020-07-21T12:54:44Z" level=info msg="database version 5.5.62, distro MySQL Community Server (GPL)" source="slave_status.go:65"  agentID=/agent_id/6879b5d2-b6c1-46ac-89a1-f0cc5dc8d5cc component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:54:44.133+00:00] time="2020-07-21T12:54:44Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/6879b5d2-b6c1-46ac-89a1-f0cc5dc8d5cc component=agent-process type
=mysqld_exporter
INFO[2020-07-21T12:54:45.222+00:00] time="2020-07-21T12:54:45Z" level=info msg="database version 5.7.31, distro MySQL Community Server (GPL)" source="slave_status.go:65"  agentID=/agent_id/db7c6d7c-ae8c-4c22-b881-5c2f69bd95bb component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:54:45.223+00:00] time="2020-07-21T12:54:45Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/db7c6d7c-ae8c-4c22-b881-5c2f69bd95bb component=agent-process type
=mysqld_exporter
INFO[2020-07-21T12:54:46.263+00:00] time="2020-07-21T12:54:46Z" level=info msg="database version 5.6.49, distro MySQL Community Server (GPL)" source="slave_status.go:65"  agentID=/agent_id/68813868-1cf7-43e2-903d-5970a95ca514 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:54:46.265+00:00] time="2020-07-21T12:54:46Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/68813868-1cf7-43e2-903d-5970a95ca514 component=agent-process type
=mysqld_exporter
INFO[2020-07-21T12:54:47.247+00:00] time="2020-07-21T12:54:47Z" level=info msg="database version 8.0.21, distro MySQL Community Server - GPL" source="slave_status.go:65"  agentID=/agent_id/11645455-ba40-43a1-b5b0-0be50b3c79d8 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:54:47.249+00:00] time="2020-07-21T12:54:47Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/11645455-ba40-43a1-b5b0-0be50b3c79d8 component=agent-process type
=mysqld_exporter
ERRO[2020-07-21T12:54:48.365+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/d61b7d46-2c25-4610-bcda-5fa9f210c2b4 component=agent-builtin type=qan_mysql
_perfschema_agent
INFO[2020-07-21T12:54:52.524+00:00] time="2020-07-21T12:54:52Z" level=error msg="Error scraping for collect.heartbeat: Error 1146: Table 'heartbeat.heartbeat' doesn't exist" source="exporter.go:116"  agentID=/agent_id/6879b5d2-b6c1-46ac-89a1-f0cc5dc8d5
cc component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:54:53.366+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/d61b7d46-2c25-4610-bcda-5fa9f210c2b4 component=agent-builtin type=qan_mysql
_perfschema_agent
INFO[2020-07-21T12:54:54.134+00:00] time="2020-07-21T12:54:54Z" level=info msg="database version 5.5.62, distro MySQL Community Server (GPL)" source="slave_status.go:65"  agentID=/agent_id/6879b5d2-b6c1-46ac-89a1-f0cc5dc8d5cc component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:54:54.136+00:00] time="2020-07-21T12:54:54Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/6879b5d2-b6c1-46ac-89a1-f0cc5dc8d5cc component=agent-process type
=mysqld_exporter
INFO[2020-07-21T12:54:55.221+00:00] time="2020-07-21T12:54:55Z" level=info msg="database version 5.7.31, distro MySQL Community Server (GPL)" source="slave_status.go:65"  agentID=/agent_id/db7c6d7c-ae8c-4c22-b881-5c2f69bd95bb component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:54:55.221+00:00] time="2020-07-21T12:54:55Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/db7c6d7c-ae8c-4c22-b881-5c2f69bd95bb component=agent-process type
=mysqld_exporter
INFO[2020-07-21T12:54:56.264+00:00] time="2020-07-21T12:54:56Z" level=info msg="database version 5.6.49, distro MySQL Community Server (GPL)" source="slave_status.go:65"  agentID=/agent_id/68813868-1cf7-43e2-903d-5970a95ca514 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:54:56.266+00:00] time="2020-07-21T12:54:56Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/68813868-1cf7-43e2-903d-5970a95ca514 component=agent-process type
=mysqld_exporter
INFO[2020-07-21T12:54:57.246+00:00] time="2020-07-21T12:54:57Z" level=info msg="database version 8.0.21, distro MySQL Community Server - GPL" source="slave_status.go:65"  agentID=/agent_id/11645455-ba40-43a1-b5b0-0be50b3c79d8 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:54:57.248+00:00] time="2020-07-21T12:54:57Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/11645455-ba40-43a1-b5b0-0be50b3c79d8 component=agent-process type
=mysqld_exporter
INFO[2020-07-21T12:47:02.013+00:00] time="2020-07-21T12:47:02Z" level=info msg="database version 5.5.61-38.13, distro Percona Server (GPL), Release 38.13, Revision 812705b" source="slave_status.go:65"  agentID=/agent_id/3c291cce-514b-4c93-a679-74a869da3efe component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:02.014+00:00] time="2020-07-21T12:47:02Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS NOLOCK" source="slave_status.go:106"  agentID=/agent_id/3c291cce-514b-4c93-a679-74a869da3efe component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:03.842+00:00] time="2020-07-21T12:47:03Z" level=info msg="database version 8.0.19-10, distro Percona Server (GPL), Release 10, Revision f446c04" source="slave_status.go:65"  agentID=/agent_id/592827d5-b428-4850-b9a0-f50b16a76637 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:03.844+00:00] time="2020-07-21T12:47:03Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/592827d5-b428-4850-b9a0-f50b16a76637 component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:47:04.538+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/1e159c98-77f2-485f-a33d-de41a134db2a component=agent-builtin type=qan_mysql_perfschema_agent
INFO[2020-07-21T12:47:07.670+00:00] time="2020-07-21T12:47:07Z" level=info msg="database version 5.6.48-88.0, distro Percona Server (GPL), Release 88.0, Revision 66735bc" source="slave_status.go:65"  agentID=/agent_id/504c1f55-f549-465a-a463-98f181e41bef component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:07.672+00:00] time="2020-07-21T12:47:07Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS NONBLOCKING" source="slave_status.go:106"  agentID=/agent_id/504c1f55-f549-465a-a463-98f181e41bef component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:08.075+00:00] time="2020-07-21T12:47:08Z" level=info msg="database version 5.7.30-33, distro Percona Server (GPL), Release 33, Revision 6517692" source="slave_status.go:65"  agentID=/agent_id/e2f7fa57-8905-4639-b346-05326d947518 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:08.080+00:00] time="2020-07-21T12:47:08Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/e2f7fa57-8905-4639-b346-05326d947518 component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:47:09.538+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/1e159c98-77f2-485f-a33d-de41a134db2a component=agent-builtin type=qan_mysql_perfschema_agent
INFO[2020-07-21T12:47:11.979+00:00] time="2020-07-21T12:47:11Z" level=info msg="database version 5.5.61-38.13, distro Percona Server (GPL), Release 38.13, Revision 812705b" source="slave_status.go:65"  agentID=/agent_id/3c291cce-514b-4c93-a679-74a869da3efe component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:11.980+00:00] time="2020-07-21T12:47:11Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS NOLOCK" source="slave_status.go:106"  agentID=/agent_id/3c291cce-514b-4c93-a679-74a869da3efe component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:13.843+00:00] time="2020-07-21T12:47:13Z" level=info msg="database version 8.0.19-10, distro Percona Server (GPL), Release 10, Revision f446c04" source="slave_status.go:65"  agentID=/agent_id/592827d5-b428-4850-b9a0-f50b16a76637 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:13.850+00:00] time="2020-07-21T12:47:13Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/592827d5-b428-4850-b9a0-f50b16a76637 component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:47:14.538+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/1e159c98-77f2-485f-a33d-de41a134db2a component=agent-builtin type=qan_mysql_perfschema_agent
INFO[2020-07-21T12:47:17.672+00:00] time="2020-07-21T12:47:17Z" level=info msg="database version 5.6.48-88.0, distro Percona Server (GPL), Release 88.0, Revision 66735bc" source="slave_status.go:65"  agentID=/agent_id/504c1f55-f549-465a-a463-98f181e41bef component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:17.673+00:00] time="2020-07-21T12:47:17Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS NONBLOCKING" source="slave_status.go:106"  agentID=/agent_id/504c1f55-f549-465a-a463-98f181e41bef component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:18.078+00:00] time="2020-07-21T12:47:18Z" level=info msg="database version 5.7.30-33, distro Percona Server (GPL), Release 33, Revision 6517692" source="slave_status.go:65"  agentID=/agent_id/e2f7fa57-8905-4639-b346-05326d947518 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:18.079+00:00] time="2020-07-21T12:47:18Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/e2f7fa57-8905-4639-b346-05326d947518 component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:47:19.540+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/1e159c98-77f2-485f-a33d-de41a134db2a component=agent-builtin type=qan_mysql_perfschema_agent
INFO[2020-07-21T12:47:21.976+00:00] time="2020-07-21T12:47:21Z" level=info msg="database version 5.5.61-38.13, distro Percona Server (GPL), Release 38.13, Revision 812705b" source="slave_status.go:65"  agentID=/agent_id/3c291cce-514b-4c93-a679-74a869da3efe component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:21.977+00:00] time="2020-07-21T12:47:21Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS NOLOCK" source="slave_status.go:106"  agentID=/agent_id/3c291cce-514b-4c93-a679-74a869da3efe component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:23.846+00:00] time="2020-07-21T12:47:23Z" level=info msg="database version 8.0.19-10, distro Percona Server (GPL), Release 10, Revision f446c04" source="slave_status.go:65"  agentID=/agent_id/592827d5-b428-4850-b9a0-f50b16a76637 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:23.847+00:00] time="2020-07-21T12:47:23Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/592827d5-b428-4850-b9a0-f50b16a76637 component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:47:24.539+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/1e159c98-77f2-485f-a33d-de41a134db2a component=agent-builtin type=qan_mysql_perfschema_agent
INFO[2020-07-21T12:47:27.667+00:00] time="2020-07-21T12:47:27Z" level=info msg="database version 5.6.48-88.0, distro Percona Server (GPL), Release 88.0, Revision 66735bc" source="slave_status.go:65"  agentID=/agent_id/504c1f55-f549-465a-a463-98f181e41bef component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:27.671+00:00] time="2020-07-21T12:47:27Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS NONBLOCKING" source="slave_status.go:106"  agentID=/agent_id/504c1f55-f549-465a-a463-98f181e41bef component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:28.076+00:00] time="2020-07-21T12:47:28Z" level=info msg="database version 5.7.30-33, distro Percona Server (GPL), Release 33, Revision 6517692" source="slave_status.go:65"  agentID=/agent_id/e2f7fa57-8905-4639-b346-05326d947518 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:28.080+00:00] time="2020-07-21T12:47:28Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/e2f7fa57-8905-4639-b346-05326d947518 component=agent-process type=mysqld_exporter
ERRO[2020-07-21T12:47:29.538+00:00] failed to query events_statements_history: Error 1146: Table 'performance_schema.events_statements_history' doesn't exist  agentID=/agent_id/1e159c98-77f2-485f-a33d-de41a134db2a component=agent-builtin type=qan_mysql_perfschema_agent
INFO[2020-07-21T12:47:31.977+00:00] time="2020-07-21T12:47:31Z" level=info msg="database version 5.5.61-38.13, distro Percona Server (GPL), Release 38.13, Revision 812705b" source="slave_status.go:65"  agentID=/agent_id/3c291cce-514b-4c93-a679-74a869da3efe component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:31.978+00:00] time="2020-07-21T12:47:31Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS NOLOCK" source="slave_status.go:106"  agentID=/agent_id/3c291cce-514b-4c93-a679-74a869da3efe component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:33.807+00:00] time="2020-07-21T12:47:33Z" level=info msg="database version 8.0.19-10, distro Percona Server (GPL), Release 10, Revision f446c04" source="slave_status.go:65"  agentID=/agent_id/592827d5-b428-4850-b9a0-f50b16a76637 component=agent-process type=mysqld_exporter
INFO[2020-07-21T12:47:33.811+00:00] time="2020-07-21T12:47:33Z" level=info msg="Successfully scraped status with query: SHOW SLAVE STATUS" source="slave_status.go:106"  agentID=/agent_id/592827d5-b428-4850-b9a0-f50b16a76637 component=agent-process type=mysqld_exporter

```

