### PR TITLE
PMM-9840 standard log level as part of issue PMM-7326

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -386,6 +386,7 @@ func main() {
 		scraperFlags[scraper] = f
 	}
 
+	log.AddFlags(kingpin.CommandLine)
 	// Parse flags.
 	kingpin.Parse()
 


### PR DESCRIPTION
[PMM-9840](https://jira.percona.com/browse/PMM-9840) as part of issue [PMM-7326](https://jira.percona.com/browse/PMM-7326)

Build: [SUBMODULES-2443](https://github.com/Percona-Lab/pmm-submodules/pull/2443)

Did simple local test with:
```bash
./mysqld_exporter --log.level=info
./mysqld_exporter --log.level=warn
./mysqld_exporter --log.level=undefined_log_level_expect_error_message
```

- [ ] https://github.com/percona/proxysql_exporter/pull/61
- [ ] https://github.com/percona/azure_metrics_exporter/pull/4