### PR TITLE
Update info_schema_processlist.go

### DIFF
--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -136,6 +136,10 @@ func deriveThreadState(command string, state string) string {
 	if strings.Contains(normState, "waiting for") && strings.Contains(normState, "lock") {
 		return "waiting for lock"
 	}
+	// this is for parallel replication state
+	if strings.Contains(normState, "waiting for an event from coordinator") {
+		return "waiting for an event from coordinator"
+	}
 	if normCmd == "sleep" && normState == "" {
 		return "idle"
 	}


### PR DESCRIPTION
What does this implement / fix?

MySQL using this process state "waiting for an event from coordinator" on parallel replication and the key is not pre-defined in the threadStateCounterMap variable on the info_schema_processlist.go file.

So this state belongs to the "executing" state since the corresponding command column represents the output 'Query' on the deriveThreadState method.

So I have implemented a separate condition for the "waiting for an event from coordinator" state.

File Modified : info_schema_processlist.go