### PR TITLE
WEB-7025: Add master_server_id label

### DIFF
--- a/collector/slave_status.go
+++ b/collector/slave_status.go
@@ -112,6 +112,7 @@ func (ScrapeSlaveStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prome
 			return err
 		}
 
+		masterServerID := columnValue(scanArgs, slaveCols, "Master_Server_Id")
 		masterUUID := columnValue(scanArgs, slaveCols, "Master_UUID")
 		masterHost := columnValue(scanArgs, slaveCols, "Master_Host")
 		channelName := columnValue(scanArgs, slaveCols, "Channel_Name")       // MySQL & Percona
@@ -123,12 +124,12 @@ func (ScrapeSlaveStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prome
 					prometheus.NewDesc(
 						prometheus.BuildFQName(namespace, slaveStatus, strings.ToLower(col)),
 						"Generic metric from SHOW SLAVE STATUS.",
-						[]string{"master_host", "master_uuid", "channel_name", "connection_name"},
+						[]string{"master_host", "master_server_id", "master_uuid", "channel_name", "connection_name"},
 						nil,
 					),
 					prometheus.UntypedValue,
 					value,
-					masterHost, masterUUID, channelName, connectionName,
+					masterHost, masterServerID, masterUUID, channelName, connectionName,
 				)
 			}
 		}

--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -45,10 +45,10 @@ func TestScrapeSlaveStatus(t *testing.T) {
 	}()
 
 	counterExpected := []MetricResult{
-		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 0, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 2, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": "", "master_server_id": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": "", "master_server_id": ""}, value: 0, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": "", "master_server_id": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": "", "master_server_id": ""}, value: 2, metricType: dto.MetricType_UNTYPED},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range counterExpected {


### PR DESCRIPTION
Add a `master_server_id` metric label.